### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ AI:  Header: { alg: "RS256" }  Payload: { sub: "1234", exp: 1700000000 }  Expire
 
 ![MCP server devutils demo — JWT decode, UUID generation, and cron explanation in Claude Desktop](assets/demo.gif)
 
+<a href="https://glama.ai/mcp/servers/ofershap/mcp-server-devutils">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/ofershap/mcp-server-devutils/badge" alt="mcp-server-devutils MCP server" />
+</a>
+
 ## Tools
 
 | Tool               | What it does                                      |


### PR DESCRIPTION
This PR adds a badge for the [mcp-server-devutils](https://glama.ai/mcp/servers/ofershap/mcp-server-devutils) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/ofershap/mcp-server-devutils">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/ofershap/mcp-server-devutils/badge" alt="mcp-server-devutils MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.