### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ AI:  Header: { alg: "RS256" }  Payload: { sub: "1234", exp: 1700000000 }  Expire
 | `json_validate`    | Validate JSON and report its type                 |
 | `regex_test`       | Test a regex pattern against a string             |
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/ofershap-mcp-server-devutils).
+
 ## Quick Start
 
 ### With Claude Desktop


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/ofershap-mcp-server-devutils)